### PR TITLE
default handler

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ Syntax sugar for events handlers. Kind of like the excellent, [classnames](https
 
 ## Usage
 
-This module gives you some special syntax to make your event handlers more declarative and functional. You can create handlers for only certain keypresses, or easily attach multiple handlers to a single event. 
+This module gives you some special syntax to make your event handlers more declarative and functional. You can create handlers for only certain keypresses, or easily attach multiple handlers to a single event.
 
 This example calls `updateText` with every keydown event, but also calls `submit` only when enter is pressed:
 
@@ -37,6 +37,17 @@ function render () {
 ```
 
 This will close the input and submit when `enter` is pressed, it will also update the text on every normal keydown.
+If your descriptor is an object, the 'default' key will match every event:
+
+```js
+var ev = require('@f/event-handler')
+
+function render () {
+  return <input onKeyDown={ev({enter: submit, default: updateText})} />
+}
+```
+
+This will submit the input when `enter` is pressed and update the text on every __other__ keydown.
 
 ## Return values
 

--- a/Readme.md
+++ b/Readme.md
@@ -32,7 +32,7 @@ You may pass an array, object, or just a plain function, and you may also do any
 var ev = require('@f/event-handler')
 
 function render () {
-  return <input onKeyDown={ev[{enter: [submit, close]}, updateText]} />
+  return <input onKeyDown={ev([{enter: [submit, close]}, updateText])} />
 }
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,14 +34,14 @@ function match (obj) {
   return function (e) {
     var chord = eventKey(e)
     var fn = obj[chord]
-    var defaultFn = obj.default;
+    var defaultFn = obj.default
 
     if (isFunction(fn)) {
       return fn(e)
     }
 
     if (isFunction(defaultFn)) {
-      return defaultFn(e);
+      return defaultFn(e)
     }
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,14 @@ function match (obj) {
   return function (e) {
     var chord = eventKey(e)
     var fn = obj[chord]
+    var defaultFn = obj.default;
 
     if (isFunction(fn)) {
       return fn(e)
+    }
+
+    if (isFunction(defaultFn)) {
+      return defaultFn(e);
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,21 @@ test('should work', function (t) {
   t.end()
 })
 
+test('default handler', function (t) {
+  var descriptor = {
+    'ctrl+shift+enter': function() {
+      return 'combination'
+    },
+    'default': function() {
+      return 'default'
+    }
+  }
+
+  t.equal(ev(descriptor)(event('ctrl+shift+enter')), 'combination')
+  t.equal(ev(descriptor)(event('x')), 'default')
+  t.end()
+})
+
 /**
  * Helpers
  */


### PR DESCRIPTION
This PR adds support for a default handler in object descriptors, feel free to merge it :grinning: 

I choose 'default' as keyname, because it acts like the default branch in a switch statement, but i am not sure whether a reserved keyword is a good name.
